### PR TITLE
export.fn looks wrong

### DIFF
--- a/javascript.md
+++ b/javascript.md
@@ -41,7 +41,7 @@ function fn() {}
 
 Exceptions:
 
-- Exporting - `export.fn = function () {}`
+- Exporting - `exports.fn = function () {}`
 - Conditionals - `var fn = a ? function () {} : function () {}`
 
 #### Spaces around function definition


### PR DESCRIPTION
This caused `Unexpected reserved word` exception in my head. :)

Should really be `exports`.

PS: `exports` or `module.exports` for export? Style guide leaves some room for ambiguity.
