### PR TITLE
add .editorconfig to template

### DIFF
--- a/template/.editorconfig
+++ b/template/.editorconfig
@@ -1,0 +1,22 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[{.,}*.{js,json,json5,yml,yaml,jade}]
+indent_style = space
+indent_size = 2
+
+[*.md]
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = false
+
+[*.jade]
+trim_trailing_whitespace = false
+
+[Makefile]
+indent_style = tab


### PR DESCRIPTION
This thing needs to be maintained somewhere. If someone wants to use it, it's better to get our version than demo from editorconfig.org that isn't actually useful for anything.

If you don't like it being in every repo, maybe move it to `config` folder or something like that. But it seems to be harmless enough to have in template.
#8
