### PR TITLE
Proposal: use spaces for grouping

### DIFF
--- a/javascript.md
+++ b/javascript.md
@@ -50,16 +50,29 @@ function fn(a, b) {}
 
 #### Spaces around operators
 
+Always put spaces after keywords (`if`, `while`, `switch`, etc.).
+
+Use spaces for grouping: put spaces around low-priority operators. 
+
 ```js
 if () {} else {}
 switch () {}
 
-for (a; b >= c; c + d / e) {}
+for (a; b >= c; c + d/e) {}
 
-// ++ -- ~ ! are exceptions
+// unary operators will usually have no space
+// after them because of their priority
 a++
 --b
 !!~array.indexOf('c')
+
+// plus has lower priority than multiplication,
+// so we're adding spaces to it to show that:
+2 + 2*2
+
+// plus has higher priority than ternary operator,
+// so we group its arguments together
+1+2 ? 3 : 4
 ```
 
 #### Spaces only after commas or semicolons in arguments


### PR DESCRIPTION
Currently style guide asks people to always put spaces around infix operators.

I suggest to change that, and use spaces for grouping. For example:

``` js
// plus has lower priority than multiplication,
// so we're adding spaces to it to show that:
2 + 2*2

// plus has higher priority than ternary operator,
// so we group its arguments together
1+2 ? 3 : 4
```

That's because not everyone remembers operator precedence table, and this way you can avoid using parenthesis while still keeping code readable.
