### PR TITLE
RFC: contributing.md

### DIFF
--- a/template/Contributing.md
+++ b/template/Contributing.md
@@ -22,6 +22,8 @@ Try to provide tests when you can; following our concise [style gude](https://gi
 However, we don't usually require that you do these things. Doing so only helps us help you get your contributions in.
 We regularly patch up things such as style nits in commits so that new contributors don't have to worry about those.
 
+All code contributed is and will be [MIT Licensed](LICENSE).
+
 
 ## Code of Conduct
 

--- a/template/Contributing.md
+++ b/template/Contributing.md
@@ -12,7 +12,7 @@ Please attempt to search for existing issues before filing a new one.
 When creating an issue, try to clearly state how to reproduce the issue, and provide example code if possible. Doing so helps us help __you__! :)
 
 We will gladly answer questions via GitHub, but you can also contact us on [Gitter](https://gitter.im/), or freenode IRC (#express, #jshttp).
-If you do not feel comfortable contacting us in public, you may email us under any email listed on our public GitHub profiles ([@Fishrock123](https://github.com/Fishrock123), [@dougwilson](https://github.com/dougwilson))
+If you do not feel comfortable contacting us in public, you may email us under any email listed on our public GitHub profiles ([@Fishrock123](https://github.com/Fishrock123), [@dougwilson](https://github.com/dougwilson)).
 
 
 ## Code Contributions
@@ -29,8 +29,8 @@ We regularly patch up things such as style nits in commits so that new contribut
 
 Until we have an official Code of Conduct, we will act against harassment according to any of the following codes as we best see fit to resolve the situation and bring safety to our community:
 
-[Conference Code of Conduct](http://confcodeofconduct.com/)
-[Contributor Covenant](https://github.com/Bantik/contributor_covenant/blob/master/CODE_OF_CONDUCT.md)
+- [Conference Code of Conduct](http://confcodeofconduct.com/)
+- [Contributor Covenant](https://github.com/Bantik/contributor_covenant/blob/master/CODE_OF_CONDUCT.md)
 
 tl;dr: Be respectful. Abusive behavior is never tolerated.
 

--- a/template/Contributing.md
+++ b/template/Contributing.md
@@ -1,0 +1,42 @@
+## Collaboration Guidlines
+
+__Anyone__ is welcome to collaborate on express and related projects (jshttp / pillarjs / etc).
+
+We aim to be a community in which anyone can participate regardless of gender, sexual orientation, ability, ethnicity, socioeconomic status, and religion (or lack thereof).­
+
+
+## Issues
+
+Please attempt to search for existing issues before filing a new one.
+
+When creating an issue, try to clearly state hwo to reproduce the issue, and provide example code if possible. Doing so helps us help __you__! :)
+
+We will gladly answer questions via GitHub, but you can also contact us on [Gitter](https://gitter.im/), or freenode IRC (#express, #jshttp).
+If you do not feel comfortable contacting us in public, you may email us under any email listed on our public GitHub profiles ([@Fishrock123](https://github.com/Fishrock123), [@dougwilson](https://github.com/dougwilson))
+
+
+## Code Contributions
+
+Try to provide tests when you can; following our concise [style gude](https://github.com/jshttp/style-guide) also helps us.
+
+However, we don't usually require that you do these things. Doing so only helps us help you get your contributions in.
+We regularily patch up things such as style nits in commits so that new contributors don't have to worry about those.
+
+
+## Code of Conduct
+
+[This is why.](https://medium.com/node-js-javascript/codes-of-conduct-82ab2d88112d)
+
+Until we have an official Code of Conduct, we will act against harassment according to any of the following codes as we best see fit to resolve the situation and bring safey to our community:
+
+[Conference Code of Conduct](http://confcodeofconduct.com/)
+[Contributor Covenant](https://github.com/Bantik/contributor_covenant/blob/master/CODE_OF_CONDUCT.md)
+
+tl;dr: Be respectful. Abusive behavior is never tolerated.
+
+
+## Notes
+
+("we" refers to the maintainers and community of express / expressjs / jshttp / pillarjs)
+
+All Code is MIT Licensed unless otherwise noted. This work is dedicated to the Public Domain.

--- a/template/Contributing.md
+++ b/template/Contributing.md
@@ -1,9 +1,17 @@
-## Collaboration Guidelines
+# Collaboration Guidelines
 
-__Anyone__ is welcome to collaborate on express and related projects (jshttp / pillarjs / etc).
+__Anyone__ is welcome to __positively__ collaborate on express and related projects (pillarjs / jshttp / etc).
 
-We aim to be a community in which anyone can participate regardless of gender, sexual orientation, ability, ethnicity, socioeconomic status, and religion (or lack thereof).­
+We aim to be a community in which anyone can __positively__ participate regardless of gender, sexual orientation, ability, ethnicity, socioeconomic status, and religion (or lack thereof).­
 
+## Code of Conduct
+
+As our Code of Conduct, we will act against public and private harassment according to any of the following codes as we best see fit to resolve the situation and bring safety to our community:
+
+- [Conference Code of Conduct](http://confcodeofconduct.com/)
+- [Contributor Covenant](https://github.com/Bantik/contributor_covenant/blob/master/CODE_OF_CONDUCT.md)
+
+tl;dr: Be respectful. Abusive presence is never tolerated.
 
 ## Issues
 
@@ -11,7 +19,7 @@ Please attempt to search for existing issues before filing a new one.
 
 When creating an issue, try to clearly state how to reproduce the issue, and provide example code if possible. Doing so helps us help __you__! :)
 
-We will gladly answer questions via GitHub, but you can also contact us on [Gitter](https://gitter.im/), or freenode IRC (#express, #jshttp).
+We will gladly answer questions via GitHub, but you can also contact us on [Gitter](https://gitter.im/), or freenode IRC ([#express](http://webchat.freenode.net/?channels=#express), [#jshttp](http://webchat.freenode.net/?channels=#jshttp)).
 If you do not feel comfortable contacting us in public, you may email us under any email listed on our public GitHub profiles ([@Fishrock123](https://github.com/Fishrock123), [@dougwilson](https://github.com/dougwilson)).
 
 
@@ -25,16 +33,11 @@ We regularly patch up things such as style nits in commits so that new contribut
 All code contributed is and will be [MIT Licensed](LICENSE).
 
 
-## Code of Conduct
-
-Until we have an official Code of Conduct, we will act against public and private harassment according to any of the following codes as we best see fit to resolve the situation and bring safety to our community:
-
-- [Conference Code of Conduct](http://confcodeofconduct.com/)
-- [Contributor Covenant](https://github.com/Bantik/contributor_covenant/blob/master/CODE_OF_CONDUCT.md)
-
-tl;dr: Be respectful. Abusive behavior is never tolerated.
-
-
 ## Notes
 
-("we" refers to the maintainers and community of express / expressjs / jshttp / pillarjs / etc)
+"we" refers to the maintainers __and__ community of the following GitHub organizations & repos:
+
+- [express](https://github.com/strongloop/express)
+- [pillarjs](https://github.com/pillarjs)
+- [jshttp](https://github.com/orgs/jshttp)
+- [expressjs](https://github.com/orgs/expressjs)

--- a/template/Contributing.md
+++ b/template/Contributing.md
@@ -17,7 +17,7 @@ If you do not feel comfortable contacting us in public, you may email us under a
 
 ## Code Contributions
 
-Try to provide tests when you can; following our concise [style gude](https://github.com/jshttp/style-guide) also helps us.
+Try to provide tests when you can; following our concise [style guide](https://github.com/jshttp/style-guide) also helps us.
 
 However, we don't usually require that you do these things. Doing so only helps us help you get your contributions in.
 We regularly patch up things such as style nits in commits so that new contributors don't have to worry about those.

--- a/template/Contributing.md
+++ b/template/Contributing.md
@@ -38,5 +38,3 @@ tl;dr: Be respectful. Abusive behavior is never tolerated.
 ## Notes
 
 ("we" refers to the maintainers and community of express / expressjs / jshttp / pillarjs)
-
-All Code is MIT Licensed unless otherwise noted. This work is dedicated to the Public Domain.

--- a/template/Contributing.md
+++ b/template/Contributing.md
@@ -25,9 +25,7 @@ We regularly patch up things such as style nits in commits so that new contribut
 
 ## Code of Conduct
 
-[This is why.](https://medium.com/node-js-javascript/codes-of-conduct-82ab2d88112d)
-
-Until we have an official Code of Conduct, we will act against harassment according to any of the following codes as we best see fit to resolve the situation and bring safety to our community:
+Until we have an official Code of Conduct, we will act against public and private harassment according to any of the following codes as we best see fit to resolve the situation and bring safety to our community:
 
 - [Conference Code of Conduct](http://confcodeofconduct.com/)
 - [Contributor Covenant](https://github.com/Bantik/contributor_covenant/blob/master/CODE_OF_CONDUCT.md)
@@ -37,4 +35,4 @@ tl;dr: Be respectful. Abusive behavior is never tolerated.
 
 ## Notes
 
-("we" refers to the maintainers and community of express / expressjs / jshttp / pillarjs)
+("we" refers to the maintainers and community of express / expressjs / jshttp / pillarjs / etc)

--- a/template/Contributing.md
+++ b/template/Contributing.md
@@ -1,4 +1,4 @@
-## Collaboration Guidlines
+## Collaboration Guidelines
 
 __Anyone__ is welcome to collaborate on express and related projects (jshttp / pillarjs / etc).
 
@@ -9,7 +9,7 @@ We aim to be a community in which anyone can participate regardless of gender, s
 
 Please attempt to search for existing issues before filing a new one.
 
-When creating an issue, try to clearly state hwo to reproduce the issue, and provide example code if possible. Doing so helps us help __you__! :)
+When creating an issue, try to clearly state how to reproduce the issue, and provide example code if possible. Doing so helps us help __you__! :)
 
 We will gladly answer questions via GitHub, but you can also contact us on [Gitter](https://gitter.im/), or freenode IRC (#express, #jshttp).
 If you do not feel comfortable contacting us in public, you may email us under any email listed on our public GitHub profiles ([@Fishrock123](https://github.com/Fishrock123), [@dougwilson](https://github.com/dougwilson))
@@ -20,14 +20,14 @@ If you do not feel comfortable contacting us in public, you may email us under a
 Try to provide tests when you can; following our concise [style gude](https://github.com/jshttp/style-guide) also helps us.
 
 However, we don't usually require that you do these things. Doing so only helps us help you get your contributions in.
-We regularily patch up things such as style nits in commits so that new contributors don't have to worry about those.
+We regularly patch up things such as style nits in commits so that new contributors don't have to worry about those.
 
 
 ## Code of Conduct
 
 [This is why.](https://medium.com/node-js-javascript/codes-of-conduct-82ab2d88112d)
 
-Until we have an official Code of Conduct, we will act against harassment according to any of the following codes as we best see fit to resolve the situation and bring safey to our community:
+Until we have an official Code of Conduct, we will act against harassment according to any of the following codes as we best see fit to resolve the situation and bring safety to our community:
 
 [Conference Code of Conduct](http://confcodeofconduct.com/)
 [Contributor Covenant](https://github.com/Bantik/contributor_covenant/blob/master/CODE_OF_CONDUCT.md)


### PR DESCRIPTION
why: https://medium.com/node-js-javascript/codes-of-conduct-82ab2d88112d

Still work in progress, but I whipped this up for now.

Once this is done(ish) and reviewed I (or we) __will__ be applying this to ever single repo under jshttp & pillarjs, as well as active expressjs repos and express / expressjs.com themselves.


Note: this will be squashed.